### PR TITLE
Fixed builds that don't require code coverage

### DIFF
--- a/step.sh
+++ b/step.sh
@@ -2,7 +2,7 @@
 set -e
 
 BUILD_COMMAND=""
-GENERATE_CODE_COVERAGE_FILES="no"
+GENERATE_CODE_COVERAGE_FILES=
 
 if [ "${is_clean_build}" == "yes" ] ; then
 	BUILD_COMMAND="clean"


### PR DESCRIPTION
the "no" string was passed to xcodebuild as an argument which made it fail all the time